### PR TITLE
Fix script

### DIFF
--- a/web/src/routes/+page.svelte
+++ b/web/src/routes/+page.svelte
@@ -115,7 +115,7 @@
             <CodeSnippet
               type="multi"
               code={Object.entries(diff)
-                .map(([idx, { hex }]) => `ma ${get_hex(idx, 2)}\nmw ${hex}`)
+                .map(([idx, { hex }]) => `${get_hex(idx, 2)}\nma\nmw ${hex}`)
                 .join('\n')}
             />
           </div>


### PR DESCRIPTION
I rememba you helped me with ma tepot and now I fund a bug in scrip generatr, if u rite `ma {addr}` it vunt vork, cos  `ma` coman looks for adres that u had specifid befor, so it shud look lik:
{addr}
ma
mw {cod}
instad of:
ma {addr}
mw {cod}
Ur version vorks but can produc cockrches (bugs)
Sorry for my bad england